### PR TITLE
fix(proxy): [CO-158] prevent 404 while loading shell using iris shell…

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -27,7 +27,7 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location /carbonio/
+    location /carbonio
     {
         try_files index.html /carbonio/;
         add_header Content-Type "text/html";

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -29,7 +29,7 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location /carbonio/
+    location /carbonio
     {
         try_files index.html /carbonio/;
         add_header Content-Type "text/html";

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -86,7 +86,7 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location /carbonio/
+    location /carbonio
     {
         try_files index.html /carbonio/;
         add_header Content-Type "text/html";

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -42,7 +42,7 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location /carbonio/
+    location /carbonio
     {
         try_files index.html /carbonio/;
         add_header Content-Type "text/html";


### PR DESCRIPTION
Let the shell load even client request URL without a trailing slash
for example domain.com/carbonio should be able to load the shell.
The previous behavior was 404 if the client miss / at the end.