### PR TITLE
envoy proxy doesn't like http 1.0, force http version 1.1 when reverse proxying

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -39,6 +39,7 @@ server
     {
         proxy_request_buffering off;
         proxy_pass http://files/;
+        proxy_http_version 1.1;
     }
 
     location = /

--- a/conf/nginx/templates/nginx.conf.web.http.template
+++ b/conf/nginx/templates/nginx.conf.web.http.template
@@ -41,6 +41,7 @@ server
     {
         proxy_request_buffering off;
         proxy_pass http://files/;
+        proxy_http_version 1.1;
     }
 
     location = /

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -98,6 +98,7 @@ server
     {
         proxy_request_buffering off;
         proxy_pass http://files/;
+        proxy_http_version 1.1;
     }
 
     location = /

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -54,6 +54,7 @@ server
     {
         proxy_request_buffering off;
         proxy_pass http://files/;
+        proxy_http_version 1.1;
     }
 
     location = /


### PR DESCRIPTION
If we don't specify the http version envoy answer with a http 426, asking the client to upgrade to http/2.0.
To avoid this error we simply specify http version 1.1 to nginx.
see https://github.com/envoyproxy/envoy/issues/2506
