### PR TITLE
refactor(packages): CO-37: enable multiserver installations

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -15,16 +15,12 @@ section="mail"
 priority="optional"
 arch="amd64"
 depends:apt=(
-  "service-discover"
-  "pending-setups"
   "carbonio-core"
   "carbonio-memcached"
   "carbonio-nginx"
   "sqlite3"
 )
 depends:yum=(
-  "service-discover"
-  "pending-setups"
   "carbonio-core"
   "carbonio-memcached"
   "carbonio-nginx"


### PR DESCRIPTION
service-discover and pending setups should be carbonio-core dependencies, because shared between multiple components. This also fix some issues on files and folders detection during the postinst phase