### PR TITLE
feat: nginx.conf.web.carbonio.admin.default.template

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -49,4 +49,8 @@ server
         add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
         alias /opt/zextras/admin/login;
     }
+
+    location /carbonioAdmin {
+        rewrite ^/carbonioAdmin(.*)$ $scheme://$host:7071/carbonioAdmin redirect;
+    }
 }


### PR DESCRIPTION
set /carbonioAdmin url rewrite to legacy admin console