### PR TITLE
chore:[CO-331] fix UI cookie behavior

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -103,8 +103,7 @@ server
             return 307 "/static/login/";
         }
 
-        #temporary redirect: do the redirection based on UI http cookie value
-        if ($cookie_UI = "iris"){
+        if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }
 

--- a/conf/nginx/templates/nginx.conf.web.http.template
+++ b/conf/nginx/templates/nginx.conf.web.http.template
@@ -105,9 +105,8 @@ server
             return 307 "/static/login/";
         }
 
-        #temporary redirect: do the redirection based on UI http cookie value
-        if ($cookie_UI = "iris"){
-            return 307 "/carbonio/";
+        if ($http_cookie !~ "UI") {
+           return 307 "/carbonio/";
         }
 
         # Begin stray redirect hack

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -162,9 +162,8 @@ server
             return 307 "/static/login/";
         }
 
-        #temporary redirect: do the redirection based on UI http cookie value
-        if ($cookie_UI = "iris"){
-            return 307 "/carbonio/";
+        if ($http_cookie !~ "UI") {
+           return 307 "/carbonio/";
         }
 
         # Begin stray redirect hack

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -118,8 +118,7 @@ server
             return 307 "/static/login/";
         }
 
-        #temporary redirect: do the redirection based on UI http cookie value
-        if ($cookie_UI = "iris"){
+        if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }
 


### PR DESCRIPTION
**Key changes:**
- IRIS is set to the standard UI if the UI cookie is not set.
- The classic app is loaded by default if a UI cookie is set and the classic app is installed.