### PR TITLE
fix: also redirect to iris shell if UI cookie is set to iris  

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -103,6 +103,10 @@ server
             return 307 "/static/login/";
         }
 
+        if ($cookie_UI = "iris"){
+           return 307 "/carbonio/";
+        }
+
         if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }

--- a/conf/nginx/templates/nginx.conf.web.http.template
+++ b/conf/nginx/templates/nginx.conf.web.http.template
@@ -105,6 +105,10 @@ server
             return 307 "/static/login/";
         }
 
+        if ($cookie_UI = "iris"){
+           return 307 "/carbonio/";
+        }
+
         if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -162,6 +162,10 @@ server
             return 307 "/static/login/";
         }
 
+        if ($cookie_UI = "iris"){
+           return 307 "/carbonio/";
+        }
+
         if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -118,6 +118,10 @@ server
             return 307 "/static/login/";
         }
 
+        if ($cookie_UI = "iris"){
+           return 307 "/carbonio/";
+        }
+
         if ($http_cookie !~ "UI") {
            return 307 "/carbonio/";
         }


### PR DESCRIPTION
- this is a temporary workaround to ensure appropriate functionality until the login component is updated.