### PR TITLE
feat: [CHATS-353] add location for chats events websocket

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -50,6 +50,17 @@ server
         proxy_http_version 1.1;
     }
 
+    location /services/chats/events
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_pass http://chats/events;
+        proxy_http_version 1.1;
+    }
+
     location /services/chats/
     {
         proxy_request_buffering off;

--- a/conf/nginx/templates/nginx.conf.web.http.template
+++ b/conf/nginx/templates/nginx.conf.web.http.template
@@ -52,6 +52,17 @@ server
         proxy_http_version 1.1;
     }
 
+    location /services/chats/events
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_pass http://chats/events;
+        proxy_http_version 1.1;
+    }
+
     location /services/chats/
     {
         proxy_request_buffering off;

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -109,6 +109,17 @@ server
         proxy_http_version 1.1;
     }
 
+    location /services/chats/events
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_pass http://chats/events;
+        proxy_http_version 1.1;
+    }
+
     location /services/chats/
     {
         proxy_request_buffering off;

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -65,6 +65,17 @@ server
         proxy_http_version 1.1;
     }
 
+    location /services/chats/events
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_request_buffering off;
+        proxy_pass http://chats/events;
+        proxy_http_version 1.1;
+    }
+
     location /services/chats/
     {
         proxy_request_buffering off;


### PR DESCRIPTION
I've added locations for /services/chats/events to proxy pass a websocket