### PR TITLE
feat: [CO-494] Add sane redirection rules for Carbonio Admin UI

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -22,7 +22,13 @@ server
 
     location /
     {
-     return 404;
+        if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie ~ "ZM_ADMIN_AUTH_TOKEN=") {
+            return 307 "/carbonioAdmin";
+        }
     }
 
     location ^~ /service

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -25,10 +25,7 @@ server
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
-
-        if ($http_cookie ~ "ZM_ADMIN_AUTH_TOKEN=") {
-            return 307 "/carbonioAdmin";
-        }
+        return 307 "/carbonioAdmin";
     }
 
     location ^~ /service

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -26,10 +26,7 @@ server
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
-
-        if ($http_cookie ~ "ZM_ADMIN_AUTH_TOKEN=") {
-            return 307 "/carbonioAdmin";
-        }
+        return 307 "/carbonioAdmin";
     }
 
     location ^~ /service

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -23,7 +23,13 @@ server
 
     location /
     {
-     return 404;
+        if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie ~ "ZM_ADMIN_AUTH_TOKEN=") {
+            return 307 "/carbonioAdmin";
+        }
     }
 
     location ^~ /service


### PR DESCRIPTION
**What has changed:**

 - redirect to login page if location is / and no admin cookie exists
 - redirect to admin panel if location is / and admin cookie exists (check for valid cookie happens on first SOAP request)
