### PR TITLE
fix: [CO-501] remove ZX_AUTH_COOKIE during Logout operation

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -105,9 +105,6 @@ server
 
     location = /
     {
-        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
-            return 307 "/static/login/";
-        }
 
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
@@ -117,6 +114,10 @@ server
             add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
 

--- a/conf/nginx/templates/nginx.conf.web.http.template
+++ b/conf/nginx/templates/nginx.conf.web.http.template
@@ -107,9 +107,6 @@ server
 
     location = /
     {
-        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
-            return 307 "/static/login/";
-        }
 
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
@@ -119,6 +116,10 @@ server
             add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
 

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -164,9 +164,6 @@ server
 
     location = /
     {
-        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
-            return 307 "/static/login/";
-        }
 
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
@@ -176,6 +173,10 @@ server
             add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
 

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -120,9 +120,6 @@ server
 
     location = /
     {
-        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
-            return 307 "/static/login/";
-        }
 
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
@@ -132,6 +129,10 @@ server
             add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            return 307 "/static/login/";
+        }
+
+        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
             return 307 "/static/login/";
         }
 


### PR DESCRIPTION
**What has changed:** 
- Logout operation now also removes ZX_AUTH_TOKEN

The removal was defined already, but the redirect check was preventing it from happening. This was fixed by changing the order of rules. 