### PR TITLE
feat: [CO-620] Enable gzip and brotli compression in proxy

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -20,6 +20,8 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    ${proxy.http.compression}
+
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -21,6 +21,8 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    ${proxy.http.compression}
+
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -52,6 +52,8 @@ server
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
     include                 ${core.includes}/${core.cprefix}.web.https.mode-${web.mailmode};
 
+    ${proxy.http.compression}
+
     set $login_upstream     ${web.upstream.login.target};
     if ($http_cookie ~ "ZM_AUTH_TOKEN=") {
         set $login_upstream    ${web.upstream.webclient.target};

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -23,6 +23,8 @@ server
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
     include                 ${core.includes}/${core.cprefix}.web.https.mode-${web.mailmode};
 
+    ${proxy.http.compression}
+
     set $login_upstream     ${web.upstream.login.target};
     if ($http_cookie ~ "ZM_AUTH_TOKEN=") {
         set $login_upstream    ${web.upstream.webclient.target};


### PR DESCRIPTION
**What has changed:**

- expand proxy http compression variable(proxy.http.compression) in server entries
    - carbonio-web app
    - carbonio-web-admin app

**Related PRs:**

- https://github.com/Zextras/carbonio-mailbox/pull/176
- https://github.com/Zextras/carbonio-jetty-conf/pull/6