### PR TITLE
chore: [CHATS-771] Rename chats and chats-messaging upstreams

### DIFF
--- a/conf/nginx/templates/nginx.conf.stream.message.dispatcher.xmpp.template
+++ b/conf/nginx/templates/nginx.conf.stream.message.dispatcher.xmpp.template
@@ -1,4 +1,4 @@
-# Chats messaging xmpp Proxy Configuration
+# Message Dispatcher Xmpp Proxy Configuration
 
 include ${core.includes}/${core.cprefix}.map.ssl;
 
@@ -16,5 +16,5 @@ server
     proxy_ssl_protocols           ${web.ssl.protocols};
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
-    proxy_pass chats-messaging-xmpp;
+    proxy_pass message-dispatcher-xmpp;
 }

--- a/conf/nginx/templates/nginx.conf.stream.message.dispatcher.xmpp.template
+++ b/conf/nginx/templates/nginx.conf.stream.message.dispatcher.xmpp.template
@@ -1,4 +1,4 @@
-# Message Dispatcher Xmpp Proxy Configuration
+# Message Dispatcher XMPP Proxy Configuration
 
 include ${core.includes}/${core.cprefix}.map.ssl;
 

--- a/conf/nginx/templates/nginx.conf.stream.template
+++ b/conf/nginx/templates/nginx.conf.stream.template
@@ -1,5 +1,5 @@
 stream {
-  upstream chats-messaging-xmpp
+  upstream message-dispatcher-xmpp
     {
         server 127.78.0.1:20005 fail_timeout=10s;
     }
@@ -10,5 +10,5 @@ stream {
     }
 
    include ${core.includes}/${core.cprefix}.stream.addressBook;
-   include ${core.includes}/${core.cprefix}.stream.chats.messaging.xmpp;
+   include ${core.includes}/${core.cprefix}.stream.message.dispatcher.xmpp;
 }

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -126,14 +126,14 @@ server
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
         proxy_request_buffering off;
-        proxy_pass http://chats/events;
+        proxy_pass http://ws-collaboration/events;
         proxy_http_version 1.1;
     }
 
     location /services/chats/
     {
         proxy_request_buffering off;
-        proxy_pass http://chats/;
+        proxy_pass http://ws-collaboration/;
         proxy_http_version 1.1;
     }
 
@@ -144,7 +144,7 @@ server
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
         proxy_request_buffering off;
-        proxy_pass http://chats-messaging-http/ws-xmpp;
+        proxy_pass http://message-dispatcher-http/ws-xmpp;
         proxy_http_version 1.1;
     }
 

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -82,14 +82,14 @@ server
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
         proxy_request_buffering off;
-        proxy_pass http://chats/events;
+        proxy_pass http://ws-collaboration/events;
         proxy_http_version 1.1;
     }
 
     location /services/chats/
     {
         proxy_request_buffering off;
-        proxy_pass http://chats/;
+        proxy_pass http://ws-collaboration/;
         proxy_http_version 1.1;
     }
 
@@ -100,7 +100,7 @@ server
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
         proxy_request_buffering off;
-        proxy_pass http://chats-messaging-http/ws-xmpp;
+        proxy_pass http://message-dispatcher-http/ws-xmpp;
         proxy_http_version 1.1;
     }
 

--- a/conf/nginx/templates/nginx.conf.web.template
+++ b/conf/nginx/templates/nginx.conf.web.template
@@ -94,7 +94,7 @@ http
         server 127.78.0.1:20000 fail_timeout=10s;
     }
 
-    upstream chats
+    upstream ws-collaboration
     {
         server 127.78.0.1:20001 fail_timeout=10s;
     }
@@ -109,7 +109,7 @@ http
         server 127.78.0.1:20003 fail_timeout=10s;
     }
 
-    upstream chats-messaging-http
+    upstream message-dispatcher-http
     {
         server 127.78.0.1:20004 fail_timeout=10s;
     }

--- a/package/carbonio-proxy.hcl
+++ b/package/carbonio-proxy.hcl
@@ -14,7 +14,7 @@ services {
             local_bind_address = "127.78.0.1"
           },
           {
-            destination_name = "carbonio-chats"
+            destination_name = "carbonio-ws-collaboration"
             local_bind_port = 20001
             local_bind_address = "127.78.0.1"
           },
@@ -29,12 +29,12 @@ services {
             local_bind_address = "127.78.0.1"
           },
           {
-            destination_name = "carbonio-chats-messaging-http"
+            destination_name = "carbonio-message-dispatcher-http"
             local_bind_port = 20004
             local_bind_address = "127.78.0.1"
           },
           {
-            destination_name = "carbonio-chats-messaging-xmpp"
+            destination_name = "carbonio-message-dispatcher-xmpp"
             local_bind_port = 20005
             local_bind_address = "127.78.0.1"
           },


### PR DESCRIPTION
Since **chats** and **chats-messaging** services have been renamed into **ws-collaboration** and **message-dispatcher,** also these files have to be changed in order to let everything works properly.

Related PR: https://github.com/Zextras/carbonio-mailbox/pull/199