### PR TITLE
chore: [AUTH-417] Access auth via service mesh

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -180,7 +180,6 @@ server
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_pass http://carbonio-auth/zx/login/;
-
     }
 
     location ^~ /zx/auth/
@@ -191,7 +190,6 @@ server
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_pass http://carbonio-auth/zx/auth/;
-
     }
 
     location = /

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -172,6 +172,28 @@ server
         proxy_http_version 1.1;
     }
 
+    location ^~ /zx/login/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_pass http://carbonio-auth/zx/login/;
+
+    }
+
+    location ^~ /zx/auth/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_pass http://carbonio-auth/zx/auth/;
+
+    }
+
     location = /
     {
 

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -128,6 +128,26 @@ server
         proxy_http_version 1.1;
     }
 
+    location ^~ /zx/login/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_pass http://carbonio-auth/zx/login/;
+    }
+
+    location ^~ /zx/auth/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_pass http://carbonio-auth/zx/auth/;
+    }
+
     location = /
     {
 

--- a/conf/nginx/templates/nginx.conf.web.template
+++ b/conf/nginx/templates/nginx.conf.web.template
@@ -71,7 +71,7 @@ http
         zmauth_zx;
     }
 
-     #  Define the collection of upstream admin client servers to which we will
+    #  Define the collection of upstream admin client servers to which we will
     #  proxy. Define each server:port against a server directive
     #
     upstream ${web.admin.upstream.adminclient.name}
@@ -87,6 +87,12 @@ http
     {
         ${web.admin.upstream.:servers}
         zmauth_admin;
+    }
+
+    #  AUTH-417 access auth via consul sidecar upstream
+    upstream carbonio-auth
+    {
+        server 127.78.0.1:20008 fail_timeout=10s;
     }
 
     upstream files

--- a/conf/nginx/templates/nginx.conf.web.template
+++ b/conf/nginx/templates/nginx.conf.web.template
@@ -89,12 +89,6 @@ http
         zmauth_admin;
     }
 
-    #  AUTH-417 access auth via consul sidecar upstream
-    upstream carbonio-auth
-    {
-        server 127.78.0.1:20008 fail_timeout=10s;
-    }
-
     upstream files
     {
         server 127.78.0.1:20000 fail_timeout=10s;
@@ -123,6 +117,11 @@ http
     upstream tasks
     {
         server 127.78.0.1:20007 fail_timeout=10s;
+    }
+
+    upstream carbonio-auth
+    {
+        server 127.78.0.1:20008 fail_timeout=10s;
     }
 
     #  Define the collection of upstream HTTP EWS servers to which we will

--- a/package/carbonio-proxy.hcl
+++ b/package/carbonio-proxy.hcl
@@ -50,7 +50,7 @@ services {
           },
           {
             destination_name = "carbonio-auth"
-            local_bind_port = 8742
+            local_bind_port = 20008
             local_bind_address = "127.78.0.1"
           }
         ]

--- a/package/carbonio-proxy.hcl
+++ b/package/carbonio-proxy.hcl
@@ -47,6 +47,11 @@ services {
             destination_name = "carbonio-tasks"
             local_bind_port = 20007
             local_bind_address = "127.78.0.1"
+          },
+          {
+            destination_name = "carbonio-auth"
+            local_bind_port = 8742
+            local_bind_address = "127.78.0.1"
           }
         ]
       }


### PR DESCRIPTION
Hello everyone,
this PR enables `carbonio-auth` access through the service mesh:
- [x] Add `carbonio-auth` upstream in the nginx templates
- [x] Add `login` and `auth` locations in the nginx templates
- [x] Add `carbonio-auth` to sidecar's upstream services