### PR TITLE
feat: [CO-677] Change path of service acl policy token

### DIFF
--- a/package/carbonio-proxy
+++ b/package/carbonio-proxy
@@ -50,13 +50,13 @@ set -e
 # Declare the service protocol
 consul config write "${SERVICE_BASE_DIR}/service-protocol.json"
 
-if [[ ! -f "/etc/zextras/carbonio-proxy/token" ]]; then
+if [[ ! -f "${SERVICE_BASE_DIR}/token" ]]; then
     # Create the token
     consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for
     ${SERVICE_NAME}/$(hostname -A)" |
-      jq -r '.SecretID' > /etc/zextras/carbonio-proxy/token;
-    chown ${SERVICE_USER}:${SERVICE_GROUP} /etc/zextras/carbonio-proxy/token
-    chmod 0600 /etc/zextras/carbonio-proxy/token
+      jq -r '.SecretID' > ${SERVICE_BASE_DIR}/token;
+    chown ${SERVICE_USER}:${SERVICE_GROUP} ${SERVICE_BASE_DIR}/token
+    chmod 0600 ${SERVICE_BASE_DIR}/token
 fi
 
 consul reload


### PR DESCRIPTION
**What has changed:**
- Proxy service ACL token now lives in new path /etc/carbonio/proxy/service-discover/token

**Tests:**
- deployed changes on VM and ran pendin-setups to run proxy setup
    - new token in created followed by consul reload
    - all services are working as expected 
